### PR TITLE
Install eslint import plugin for order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,19 @@
 {
   "extends": [
     "next/core-web-vitals",
-    "plugin:@stylistic/recommended-extends"
+    "plugin:@stylistic/recommended-extends",
+    "plugin:import/recommended",
+    "plugin:import/typescript"
   ],
   "plugins": [
-    "@stylistic/eslint-plugin"
+    "@stylistic/eslint-plugin",
+    "import"
   ],
   "rules": {
+    "import/order": ["error", {
+      "newlines-between": "always",
+      "distinctGroup": false
+    }],
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "no-trailing-spaces": "error",
     "@stylistic/indent": ["error", 2],

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,8 @@
         "copy-webpack-plugin": "^12.0.2",
         "eslint": "^8",
         "eslint-config-next": "14.0.1",
+        "eslint-import-resolver-typescript": "^3.6.1",
+        "eslint-plugin-import": "^2.29.1",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "postcss": "^8",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "copy-webpack-plugin": "^12.0.2",
     "eslint": "^8",
     "eslint-config-next": "14.0.1",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.29.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "postcss": "^8",


### PR DESCRIPTION
## Notes
Enforce a convention in the order of require() / import statements.

#### Example
```jsx
// 1. node "builtin" modules
import fs from 'fs';
import path from 'path';
// 2. "external" modules
import _ from 'lodash';
import chalk from 'chalk';
// 3. "internal" modules
// (if you have configured your path or webpack to handle your internal paths differently)
import foo from 'src/foo';
// 4. modules from a "parent" directory
import foo from '../foo';
import qux from '../../foo/qux';
// 5. "sibling" modules from the same or a sibling's directory
import bar from './bar';
import baz from './bar/baz';
// 6. "index" of the current directory
import main from './';
// 7. "object"-imports (only available in TypeScript)
import log = console.log;
// 8. "type" imports (only available in Flow and TypeScript)
import type { Foo } from 'foo';
```

Read more https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md