### PR TITLE
Fix provider crash in conversation settings component

### DIFF
--- a/app/components/conversation/Settings.tsx
+++ b/app/components/conversation/Settings.tsx
@@ -31,8 +31,8 @@ export function Settings() {
           <SelectItem key={assistant.id} value={assistant.id} textValue={assistant.name}>
             <div className="flex flex-col gap-1">
               <span className="text-small">{assistant.name}</span>
-              <span className="text-tiny text-default-400">Model: {assistant.model.model}</span>
-              <span className="text-tiny text-default-400">Transcriber: {assistant.transcriber.provider} / {assistant.transcriber.model}</span>
+              <span className="text-tiny text-default-400">Model: {assistant.model?.model ?? ''}</span>
+              <span className="text-tiny text-default-400">Transcriber: {assistant.transcriber?.provider ?? ''} / {assistant.transcriber?.model ?? ''}</span>
             </div>
           </SelectItem>
         ))}


### PR DESCRIPTION
The  demo crashed because one of the assistants in the Vapi UI had not been published since updating the transcriber provider. That one missing provider prevented the whole demo from running.  This is a hot fix to help prevent that in the future, although it would probably be better to not even show the assistant with missing models or transcribers. 