### PR TITLE
Conclude session when call is ended

### DIFF
--- a/app/components/conversation/Conversation.tsx
+++ b/app/components/conversation/Conversation.tsx
@@ -17,6 +17,9 @@ function Conversation() {
     onCallStarted(_call) {
       setState(ConversationState.STARTED);
     },
+    onCallEnded() {
+      setState(ConversationState.ENDED);
+    },
   });
 
   switch (state) {
@@ -41,7 +44,6 @@ function Conversation() {
           audioLevel={audioLevel}
           onEndCall={() => {
             stop();
-            setState(ConversationState.ENDED);
           }}
         />
       );

--- a/app/lib/vapi/useVapi.ts
+++ b/app/lib/vapi/useVapi.ts
@@ -11,9 +11,10 @@ import { vapi } from './vapi.sdk';
 export interface UseVapiProps {
   assistantId?: string;
   onCallStarted?: (call: Call) => void;
+  onCallEnded?: () => void;
 }
 
-export function useVapi({ onCallStarted, assistantId }: UseVapiProps = {}) {
+export function useVapi({ onCallStarted, assistantId, onCallEnded }: UseVapiProps = {}) {
   const [isAssistantSpeeching, setIsAssistantSpeeching] = useState(false);
 
   const [call, setCall] = useState<Call>();
@@ -42,6 +43,7 @@ export function useVapi({ onCallStarted, assistantId }: UseVapiProps = {}) {
     const onCallEnd = () => {
       console.log('Call has stopped');
       setCallStatus(CallStatus.INACTIVE);
+      onCallEnded?.();
     };
 
     const onVolumeLevel = (volume: number) => {


### PR DESCRIPTION
### Notes
- In your assistant's prompt. Enable End Call function feature and just trigger it at the end of the prompt. User will be automatically taken to the end screen.